### PR TITLE
doc-remove-include-attribute-file

### DIFF
--- a/workshop/docs/modules/ROOT/pages/automating-workflows-with-pipelines.adoc
+++ b/workshop/docs/modules/ROOT/pages/automating-workflows-with-pipelines.adoc
@@ -1,8 +1,6 @@
 [id='automating-workflows-with-pipelines_{context}']
 = Automating workflows with data science pipelines
 
-include::_attributes.adoc[]
-
 In previous sections of this {deliverable}, you used a notebook to train and save your data model. Optionally, you can automate these tasks by using {productname-long} pipelines. Pipelines offer a way to automate the execution of multiple notebooks and Python code. By using pipelines, you can execute long training jobs or retrain your models on a schedule without having to manually run them in a notebook.
 
 In this section, you create a simple pipeline by using the GUI pipeline editor. The pipeline uses the notebook that you used in previous sections, to train a model and then save it to S3 storage.

--- a/workshop/docs/modules/ROOT/pages/creating-a-workbench.adoc
+++ b/workshop/docs/modules/ROOT/pages/creating-a-workbench.adoc
@@ -1,8 +1,6 @@
 [id='creating-a-workbench_{context}']
 = Creating a workbench and selecting a Notebook image
 
-include::_attributes.adoc[]
-
 A workbench is an instance of your development and experimentation environment. Within the workbench you can select a notebook image for your data science work.
 
 .Prerequisite

--- a/workshop/docs/modules/ROOT/pages/creating-data-connections-to-storage.adoc
+++ b/workshop/docs/modules/ROOT/pages/creating-data-connections-to-storage.adoc
@@ -1,8 +1,6 @@
 [id='creating-data-connections-to-storage_{context}']
 == Creating data connections to your own S3-compatible object storage
 
-include::_attributes.adoc[]
-
 NOTE: If you do not have your own s3-compatible storage, or if you want to use a disposable local Minio instance instead, skip this section and follow the steps in xref:running-a-script-to-install-storage.adoc[Running a script to install local object storage buckets and create data connections].
 
 .Prerequisite

--- a/workshop/docs/modules/ROOT/pages/deploying-a-data-model.adoc
+++ b/workshop/docs/modules/ROOT/pages/deploying-a-data-model.adoc
@@ -1,8 +1,6 @@
 [id='deploying-a-data-model_{context}']
 = Deploying a data model
 
-include::_attributes.adoc[]
-
 Now that the data model is accessible in storage and saved in the portable ONNX format, you can use an {productname-short} model server to deploy it as an API.
 
 {productname-short} multi-model servers can host several models at once. You create a new model server and deploy your model to it.

--- a/workshop/docs/modules/ROOT/pages/enabling-data-science-pipelines.adoc
+++ b/workshop/docs/modules/ROOT/pages/enabling-data-science-pipelines.adoc
@@ -1,8 +1,6 @@
 [id='enabling-data-science-pipelines_{context}']
 = Enabling data science pipelines
 
-include::_attributes.adoc[]
-
 NOTE: If you do not intend to complete the pipelines section of the workshop you can skip this step and move on to the next section, xref:creating-a-workbench.adoc[Create a Workbench]
 
 

--- a/workshop/docs/modules/ROOT/pages/importing-files-into-jupyter.adoc
+++ b/workshop/docs/modules/ROOT/pages/importing-files-into-jupyter.adoc
@@ -1,8 +1,6 @@
 [id='importing-files-into-jupyter_{context}']
 = Importing the {deliverable} files into the Jupyter environment
 
-include::_attributes.adoc[]
-
 The Jupyter environment is a web-based environment, but everything you do inside it happens on *{productname-long}* and powered by the *OpenShift* cluster. This means that, without having to install and maintain anything on your own computer, and without disposing of lots of local resources like CPU, GPU and RAM, you can conduct your Data Science work in this powerful and stable managed environment.
 
 .Prerequisite

--- a/workshop/docs/modules/ROOT/pages/navigating-to-the-dashboard.adoc
+++ b/workshop/docs/modules/ROOT/pages/navigating-to-the-dashboard.adoc
@@ -1,8 +1,6 @@
 [id='navigating-to-the-dashboard_{context}']
 = Navigating to the {productname-short} dashboard
 
-include::_attributes.adoc[]
-
 .Procedure
 
 . After you log in to the OpenShift console, access the {productname-short} dashboard by clicking the application launcher icon on the header.

--- a/workshop/docs/modules/ROOT/pages/preparing-a-data-model-for-deployment.adoc
+++ b/workshop/docs/modules/ROOT/pages/preparing-a-data-model-for-deployment.adoc
@@ -1,6 +1,5 @@
 [id='preparing-a-data-model-for-deployment_{context}']
 = Preparing a data model for deployment
-include::_attributes.adoc[]
 
 After you train a model, you can deploy it by using the {productname-short} model serving capabilities.
 

--- a/workshop/docs/modules/ROOT/pages/running-a-pipeline-generated-from-python-code.adoc
+++ b/workshop/docs/modules/ROOT/pages/running-a-pipeline-generated-from-python-code.adoc
@@ -1,8 +1,6 @@
 [id='running-a-pipeline-generated-from-python-code_{context}']
 = Running a data science pipeline generated from Python code
 
-include::_attributes.adoc[]
-
 In the previous scetion, you created a simple pipeline by using the GUI pipeline editor, it's often desirable to create pipelines by using code that can be version-controlled and shared with others. The https://github.com/kubeflow/kfp-tekton[kfp-tekton] SDK provides a Python API for creating pipelines. The SDK is available as a Python package that you can install by using the `pip install kfp-tekton` command. With this package, you can use Python code to create a pipeline and then compile it to Tekton YAML. Then you can import the YAML code into {productname-short}.
 
 This {deliverable} does not delve into the details of how to use the SDK. Instead, it provides the files for you to view and upload.

--- a/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
+++ b/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
@@ -1,8 +1,6 @@
 [id='running-a-script-to-install-storage_{context}']
 = Running a script to install local object storage buckets and create data connections
 
-include::_attributes.adoc[]
-
 For convenience, the provided script installs two data connections (and associated secrets) and two Minio buckets as s3-compatible storage The script creates a random user and password for security. This script is based on the instructions for installing Minio in this https://ai-on-openshift.io/tools-and-applications/minio/minio/[guide].
 
 IMPORTANT: The storage buckets that this script creates are *not* meant for production usage.

--- a/workshop/docs/modules/ROOT/pages/running-code-in-a-notebook.adoc
+++ b/workshop/docs/modules/ROOT/pages/running-code-in-a-notebook.adoc
@@ -1,8 +1,6 @@
 [id='running-code-in-a-notebook_{context}']
 = Running code in a notebook
 
-include::_attributes.adoc[]
-
 NOTE: If you're already at ease with Jupyter, you can xref:training-a-data-model.adoc[skip to the next section].
 
 A notebook is an environment where you have _cells_ that can display formatted text or code.

--- a/workshop/docs/modules/ROOT/pages/setting-up-your-data-science-project.adoc
+++ b/workshop/docs/modules/ROOT/pages/setting-up-your-data-science-project.adoc
@@ -1,8 +1,6 @@
 [id='setting-up-your-data-science-project_{context}']
 = Setting up your data science project
 
-include::_attributes.adoc[]
-
 Before you begin, make sure that you are logged in to *{productname-long}* and that you can see the dashboard:
 
 image::projects/dashboard-enabled.png[Dashboard Enabled]

--- a/workshop/docs/modules/ROOT/pages/storing-data-with-data-connections.adoc
+++ b/workshop/docs/modules/ROOT/pages/storing-data-with-data-connections.adoc
@@ -1,8 +1,6 @@
 [id='storing-data-with-data-connections_{context}']
 = Storing data with data connections
 
-include::_attributes.adoc[]
-
 For this {deliverable}, you need two S3-compatible object storage buckets, such as Ceph, Minio, or AWS S3:
 
 * *My Storage* - Use this bucket for storing your models and data. You can reuse this bucket and its connection for your notebooks and model servers.

--- a/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
+++ b/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
@@ -1,8 +1,6 @@
 [id='testing-the-model-api_{context}']
 = Testing the model API
 
-include::_attributes.adoc[]
-
 Now that you've deployed the model, you can test its API endpoints.
 
 When you created the model server, you did *not* create a route for external access to the API and you did not protect it with an authentication token. By default, if you do not specify external access, the model server provides an internal endpoint with no authentication. 

--- a/workshop/docs/modules/ROOT/pages/training-a-data-model.adoc
+++ b/workshop/docs/modules/ROOT/pages/training-a-data-model.adoc
@@ -1,11 +1,7 @@
 [id='training-a-data-model_{context}']
 = Training a data model 
 
-include::_attributes.adoc[]
-
 Now that you know how the Jupyter notebook environment works, the real work can begin!
-
-//need to describe the provided data model? train a model for inference, fraud detection?
 
 In your notebook environment, open the file `1_experiment_train.ipynb`, and follow the instructions directly in the notebook. The instructions guide you through some simple data exploration, experimentation, and data model training tasks.
 


### PR DESCRIPTION
removes the include statement for the attribute from the pages adoc files - can the include be added in a higher level file instead?