### PR TITLE
Add meaningful example to the rest/grpc requests to the model

### DIFF
--- a/3_rest_requests_multi_model.ipynb
+++ b/3_rest_requests_multi_model.ipynb
@@ -99,68 +99,73 @@
    ]
   },
   {
-        "cell_type": "markdown",
-        "metadata": {},
-        "source": [
-         "## Example 1: user buys a caffe\n",
-         "\n",
-         "In this example, the user is buying a caffe. The parameters given to the model are:\n",
-         "* same location as the last transaction (distance=0)\n",
-         "* same median price (ratio_to_median=1)\n",
-         "* using pin number (pin=1)\n",
-         "* using chip (chip=1)\n",
-         "* no online transaction (online=0)"
-        ]
-       },
-       {
-        "cell_type": "code",
-        "execution_count": null,
-        "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
-        "metadata": {},
-        "outputs": [],
-        "source": [
-         "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
-         "prediction = rest_request(data)\n",
-         "prediction\n",
-         "threshhold = 0.995\n",
-         "\n",
-         "if (prediction[0] > threshhold):\n",
-         "    print('The model thinks this is a fraud')\n",
-         "else:\n",
-         "    print('The model thinks this is not a fraud')"
-        ]
-       },
-       {
-        "cell_type": "markdown",
-        "metadata": {},
-        "source": [
-         "## Example 2: fraudolent transaction\n",
-         "\n",
-         "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
-         "* very far away from latest transaction (distance=100)\n",
-         "* similar median price (ratio_to_median=1.2)\n",
-         "* not using chip (chip=0)\n",
-         "* not using pin number (pin=0)\n",
-         "* online transaction (online=1)"
-        ]
-       },
-       {
-        "cell_type": "code",
-        "execution_count": null,
-        "metadata": {},
-        "outputs": [],
-        "source": [
-         "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
-         "prediction = rest_request(data)\n",
-         "prediction\n",
-         "threshhold = 0.995\n",
-         "\n",
-         "if (prediction[0] > threshhold):\n",
-         "    print('The model thinks this is a fraud')\n",
-         "else:\n",
-         "    print('The model thinks this is not a fraud')"
-        ]
-       }
+   "cell_type": "markdown",
+   "id": "5697c2ff",
+   "metadata": {},
+   "source": [
+    "## Example 1: user buys a coffee\n",
+    "\n",
+    "In this example, the user is buying a coffee. The parameters given to the model are:\n",
+    "* same location as the last transaction (distance=0)\n",
+    "* same median price (ratio_to_median=1)\n",
+    "* using pin number (pin=1)\n",
+    "* using chip (chip=1)\n",
+    "* no online transaction (online=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0393a5a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
+    "prediction = rest_request(data)\n",
+    "prediction\n",
+    "threshhold = 0.995\n",
+    "\n",
+    "if (prediction[0] > threshhold):\n",
+    "    print('The model thinks this is fraud')\n",
+    "else:\n",
+    "    print('The model thinks this is not fraud')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e889cdd6",
+   "metadata": {},
+   "source": [
+    "## Example 2: fraudulent transaction\n",
+    "\n",
+    "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
+    "* very far away from latest transaction (distance=100)\n",
+    "* similar median price (ratio_to_median=1.2)\n",
+    "* not using chip (chip=0)\n",
+    "* not using pin number (pin=0)\n",
+    "* online transaction (online=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5deba1d5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
+    "prediction = rest_request(data)\n",
+    "prediction\n",
+    "threshhold = 0.995\n",
+    "\n",
+    "if (prediction[0] > threshhold):\n",
+    "    print('The model thinks this is fraud')\n",
+    "else:\n",
+    "    print('The model thinks this is not fraud')"
+   ]
+  }
  ],
  "metadata": {
   "kernelspec": {
@@ -178,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/3_rest_requests_multi_model.ipynb
+++ b/3_rest_requests_multi_model.ipynb
@@ -107,10 +107,10 @@
     "\n",
     "In this example, the user is buying a coffee. The parameters given to the model are:\n",
     "* same location as the last transaction (distance=0)\n",
-    "* same median price (ratio_to_median=1)\n",
-    "* using pin number (pin=1)\n",
-    "* using chip (chip=1)\n",
-    "* no online transaction (online=0)"
+    "* same median price as the last transaction (ratio_to_median=1)\n",
+    "* using a pin number (pin=1)\n",
+    "* using the credit card chip (chip=1)\n",
+    "* not an online transaction (online=0)"
    ]
   },
   {
@@ -122,13 +122,12 @@
    "source": [
     "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
     "prediction = rest_request(data)\n",
-    "prediction\n",
     "threshhold = 0.995\n",
     "\n",
     "if (prediction[0] > threshhold):\n",
-    "    print('The model thinks this is fraud')\n",
+    "    print('The model predicts that this is fraud')\n",
     "else:\n",
-    "    print('The model thinks this is not fraud')"
+    "    print('The model predicts that this is not fraud')"
    ]
   },
   {
@@ -138,12 +137,12 @@
    "source": [
     "## Example 2: fraudulent transaction\n",
     "\n",
-    "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
-    "* very far away from latest transaction (distance=100)\n",
-    "* similar median price (ratio_to_median=1.2)\n",
-    "* not using chip (chip=0)\n",
-    "* not using pin number (pin=0)\n",
-    "* online transaction (online=1)"
+    "In this example, someone stole the user's credit card and is buying something online. The parameters given to the model are:\n",
+    "* very far away from the last transaction (distance=100)\n",
+    "* median price similar to the last transaction (ratio_to_median=1.2)\n",
+    "* not using a pin number (pin=0)\n",
+    "* not using the credit card chip (chip=0)\n",
+    "* is an online transaction (online=1)"
    ]
   },
   {
@@ -157,13 +156,12 @@
    "source": [
     "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
     "prediction = rest_request(data)\n",
-    "prediction\n",
     "threshhold = 0.995\n",
     "\n",
     "if (prediction[0] > threshhold):\n",
-    "    print('The model thinks this is fraud')\n",
+    "    print('The model predicts that this is fraud')\n",
     "else:\n",
-    "    print('The model thinks this is not fraud')"
+    "    print('The model predicts that this is not fraud')"
    ]
   }
  ],

--- a/3_rest_requests_multi_model.ipynb
+++ b/3_rest_requests_multi_model.ipynb
@@ -97,7 +97,70 @@
     "else:\n",
     "    print('not fraud')"
    ]
-  }
+  },
+  {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+         "## Example 1: user buys a caffe\n",
+         "\n",
+         "In this example, the user is buying a caffe. The parameters given to the model are:\n",
+         "* same location as the last transaction (distance=0)\n",
+         "* same median price (ratio_to_median=1)\n",
+         "* using pin number (pin=1)\n",
+         "* using chip (chip=1)\n",
+         "* no online transaction (online=0)"
+        ]
+       },
+       {
+        "cell_type": "code",
+        "execution_count": null,
+        "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
+        "metadata": {},
+        "outputs": [],
+        "source": [
+         "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
+         "prediction = rest_request(data)\n",
+         "prediction\n",
+         "threshhold = 0.995\n",
+         "\n",
+         "if (prediction[0] > threshhold):\n",
+         "    print('The model thinks this is a fraud')\n",
+         "else:\n",
+         "    print('The model thinks this is not a fraud')"
+        ]
+       },
+       {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+         "## Example 2: fraudolent transaction\n",
+         "\n",
+         "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
+         "* very far away from latest transaction (distance=100)\n",
+         "* similar median price (ratio_to_median=1.2)\n",
+         "* not using chip (chip=0)\n",
+         "* not using pin number (pin=0)\n",
+         "* online transaction (online=1)"
+        ]
+       },
+       {
+        "cell_type": "code",
+        "execution_count": null,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+         "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
+         "prediction = rest_request(data)\n",
+         "prediction\n",
+         "threshhold = 0.995\n",
+         "\n",
+         "if (prediction[0] > threshhold):\n",
+         "    print('The model thinks this is a fraud')\n",
+         "else:\n",
+         "    print('The model thinks this is not a fraud')"
+        ]
+       }
  ],
  "metadata": {
   "kernelspec": {

--- a/4_grpc_requests_multi_model.ipynb
+++ b/4_grpc_requests_multi_model.ipynb
@@ -105,7 +105,6 @@
     "    inputs[0].datatype = \"FP32\"\n",
     "    inputs[0].shape.extend([1, 5])\n",
     "    inputs[0].contents.fp32_contents.extend(data)\n",
-    "    print(inputs)\n",
     "\n",
     "    # request building\n",
     "    request = grpc_predict_v2_pb2.ModelInferRequest()\n",
@@ -133,17 +132,8 @@
    "outputs": [],
    "source": [
     "data = [0.3111400080477545, 1.9459399775518593, 1.0, 0.0, 0.0]\n",
-    "prediction = grpc_request(data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f1e2cbfa-848c-4f9e-891c-45ff8658b673",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prediction[0]"
+    "prediction = grpc_request(data)\n",
+    "prediction"
    ]
   },
   {
@@ -155,7 +145,7 @@
    "source": [
     "threshhold = 0.995\n",
     "\n",
-    "if (prediction > threshhold):\n",
+    "if (prediction[0] > threshhold):\n",
     "    print('fraud')\n",
     "else:\n",
     "    print('not fraud')"
@@ -170,10 +160,10 @@
     "\n",
     "In this example, the user is buying a coffee. The parameters given to the model are:\n",
     "* same location as the last transaction (distance=0)\n",
-    "* same median price (ratio_to_median=1)\n",
-    "* using pin number (pin=1)\n",
-    "* using chip (chip=1)\n",
-    "* no online transaction (online=0)"
+    "* same median price as the last transaction (ratio_to_median=1)\n",
+    "* using a pin number (pin=1)\n",
+    "* using the credit card chip (chip=1)\n",
+    "* not an online transaction (online=0)"
    ]
   },
   {
@@ -185,13 +175,12 @@
    "source": [
     "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
     "prediction = grpc_request(data)\n",
-    "prediction[0]\n",
     "threshhold = 0.995\n",
     "\n",
     "if (prediction[0] > threshhold):\n",
-    "    print('The model thinks this is fraud')\n",
+    "    print('The model predicts that this is fraud')\n",
     "else:\n",
-    "    print('The model thinks this is not fraud')"
+    "    print('The model predicts that this is not fraud')"
    ]
   },
   {
@@ -201,12 +190,12 @@
    "source": [
     "## Example 2: fraudulent transaction\n",
     "\n",
-    "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
-    "* very far away from latest transaction (distance=100)\n",
-    "* similar median price (ratio_to_median=1.2)\n",
-    "* not using chip (chip=0)\n",
-    "* not using pin number (pin=0)\n",
-    "* online transaction (online=1)"
+    "In this example, someone stole the user's credit card and is buying something online. The parameters given to the model are:\n",
+    "* very far away from the last transaction (distance=100)\n",
+    "* median price similar to the last transaction (ratio_to_median=1.2)\n",
+    "* not using a pin number (pin=0)\n",
+    "* not using the credit card chip (chip=0)\n",
+    "* is an online transaction (online=1)"
    ]
   },
   {
@@ -220,13 +209,12 @@
    "source": [
     "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
     "prediction = grpc_request(data)\n",
-    "prediction[0]\n",
     "threshhold = 0.995\n",
     "\n",
     "if (prediction[0] > threshhold):\n",
-    "    print('The model thinks this is fraud')\n",
+    "    print('The model predicts that this is fraud')\n",
     "else:\n",
-    "    print('The model thinks this is not fraud')"
+    "    print('The model predicts that this is not fraud')"
    ]
   }
  ],

--- a/4_grpc_requests_multi_model.ipynb
+++ b/4_grpc_requests_multi_model.ipynb
@@ -162,68 +162,73 @@
    ]
   },
   {
-        "cell_type": "markdown",
-        "metadata": {},
-        "source": [
-         "## Example 1: user buys a caffe\n",
-         "\n",
-         "In this example, the user is buying a caffe. The parameters given to the model are:\n",
-         "* same location as the last transaction (distance=0)\n",
-         "* same median price (ratio_to_median=1)\n",
-         "* using pin number (pin=1)\n",
-         "* using chip (chip=1)\n",
-         "* no online transaction (online=0)"
-        ]
-       },
-       {
-        "cell_type": "code",
-        "execution_count": null,
-        "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
-        "metadata": {},
-        "outputs": [],
-        "source": [
-         "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
-         "prediction = grpc_request(data)\n",
-         "prediction[0]\n",
-         "threshhold = 0.995\n",
-         "\n",
-         "if (prediction[0] > threshhold):\n",
-         "    print('The model thinks this is a fraud')\n",
-         "else:\n",
-         "    print('The model thinks this is not a fraud')"
-        ]
-       },
-       {
-        "cell_type": "markdown",
-        "metadata": {},
-        "source": [
-         "## Example 2: fraudolent transaction\n",
-         "\n",
-         "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
-         "* very far away from latest transaction (distance=100)\n",
-         "* similar median price (ratio_to_median=1.2)\n",
-         "* not using chip (chip=0)\n",
-         "* not using pin number (pin=0)\n",
-         "* online transaction (online=1)"
-        ]
-       },
-       {
-        "cell_type": "code",
-        "execution_count": null,
-        "metadata": {},
-        "outputs": [],
-        "source": [
-         "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
-         "prediction = grpc_request(data)\n",
-         "prediction[0]\n",
-         "threshhold = 0.995\n",
-         "\n",
-         "if (prediction[0] > threshhold):\n",
-         "    print('The model thinks this is a fraud')\n",
-         "else:\n",
-         "    print('The model thinks this is not a fraud')"
-        ]
-       }
+   "cell_type": "markdown",
+   "id": "1d7f6b51",
+   "metadata": {},
+   "source": [
+    "## Example 1: user buys a coffee\n",
+    "\n",
+    "In this example, the user is buying a coffee. The parameters given to the model are:\n",
+    "* same location as the last transaction (distance=0)\n",
+    "* same median price (ratio_to_median=1)\n",
+    "* using pin number (pin=1)\n",
+    "* using chip (chip=1)\n",
+    "* no online transaction (online=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
+    "prediction = grpc_request(data)\n",
+    "prediction[0]\n",
+    "threshhold = 0.995\n",
+    "\n",
+    "if (prediction[0] > threshhold):\n",
+    "    print('The model thinks this is fraud')\n",
+    "else:\n",
+    "    print('The model thinks this is not fraud')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1dd27d88",
+   "metadata": {},
+   "source": [
+    "## Example 2: fraudulent transaction\n",
+    "\n",
+    "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
+    "* very far away from latest transaction (distance=100)\n",
+    "* similar median price (ratio_to_median=1.2)\n",
+    "* not using chip (chip=0)\n",
+    "* not using pin number (pin=0)\n",
+    "* online transaction (online=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a736a21",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
+    "prediction = grpc_request(data)\n",
+    "prediction[0]\n",
+    "threshhold = 0.995\n",
+    "\n",
+    "if (prediction[0] > threshhold):\n",
+    "    print('The model thinks this is fraud')\n",
+    "else:\n",
+    "    print('The model thinks this is not fraud')"
+   ]
+  }
  ],
  "metadata": {
   "kernelspec": {
@@ -241,7 +246,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/4_grpc_requests_multi_model.ipynb
+++ b/4_grpc_requests_multi_model.ipynb
@@ -160,7 +160,70 @@
     "else:\n",
     "    print('not fraud')"
    ]
-  }
+  },
+  {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+         "## Example 1: user buys a caffe\n",
+         "\n",
+         "In this example, the user is buying a caffe. The parameters given to the model are:\n",
+         "* same location as the last transaction (distance=0)\n",
+         "* same median price (ratio_to_median=1)\n",
+         "* using pin number (pin=1)\n",
+         "* using chip (chip=1)\n",
+         "* no online transaction (online=0)"
+        ]
+       },
+       {
+        "cell_type": "code",
+        "execution_count": null,
+        "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
+        "metadata": {},
+        "outputs": [],
+        "source": [
+         "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
+         "prediction = grpc_request(data)\n",
+         "prediction[0]\n",
+         "threshhold = 0.995\n",
+         "\n",
+         "if (prediction[0] > threshhold):\n",
+         "    print('The model thinks this is a fraud')\n",
+         "else:\n",
+         "    print('The model thinks this is not a fraud')"
+        ]
+       },
+       {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+         "## Example 2: fraudolent transaction\n",
+         "\n",
+         "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
+         "* very far away from latest transaction (distance=100)\n",
+         "* similar median price (ratio_to_median=1.2)\n",
+         "* not using chip (chip=0)\n",
+         "* not using pin number (pin=0)\n",
+         "* online transaction (online=1)"
+        ]
+       },
+       {
+        "cell_type": "code",
+        "execution_count": null,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+         "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
+         "prediction = grpc_request(data)\n",
+         "prediction[0]\n",
+         "threshhold = 0.995\n",
+         "\n",
+         "if (prediction[0] > threshhold):\n",
+         "    print('The model thinks this is a fraud')\n",
+         "else:\n",
+         "    print('The model thinks this is not a fraud')"
+        ]
+       }
  ],
  "metadata": {
   "kernelspec": {

--- a/5_rest_requests_single_model.ipynb
+++ b/5_rest_requests_single_model.ipynb
@@ -106,68 +106,81 @@
    ]
   },
   {
-        "cell_type": "markdown",
-        "metadata": {},
-        "source": [
-         "## Example 1: user buys a caffe\n",
-         "\n",
-         "In this example, the user is buying a caffe. The parameters given to the model are:\n",
-         "* same location as the last transaction (distance=0)\n",
-         "* same median price (ratio_to_median=1)\n",
-         "* using pin number (pin=1)\n",
-         "* using chip (chip=1)\n",
-         "* no online transaction (online=0)"
-        ]
-       },
-       {
-        "cell_type": "code",
-        "execution_count": null,
-        "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
-        "metadata": {},
-        "outputs": [],
-        "source": [
-         "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
-         "prediction = rest_request(data)\n",
-         "prediction\n",
-         "threshhold = 0.995\n",
-         "\n",
-         "if (prediction[0] > threshhold):\n",
-         "    print('The model thinks this is a fraud')\n",
-         "else:\n",
-         "    print('The model thinks this is not a fraud')"
-        ]
-       },
-       {
-        "cell_type": "markdown",
-        "metadata": {},
-        "source": [
-         "## Example 2: fraudolent transaction\n",
-         "\n",
-         "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
-         "* very far away from latest transaction (distance=100)\n",
-         "* similar median price (ratio_to_median=1.2)\n",
-         "* not using chip (chip=0)\n",
-         "* not using pin number (pin=0)\n",
-         "* online transaction (online=1)"
-        ]
-       },
-       {
-        "cell_type": "code",
-        "execution_count": null,
-        "metadata": {},
-        "outputs": [],
-        "source": [
-         "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
-         "prediction = rest_request(data)\n",
-         "prediction\n",
-         "threshhold = 0.995\n",
-         "\n",
-         "if (prediction[0] > threshhold):\n",
-         "    print('The model thinks this is a fraud')\n",
-         "else:\n",
-         "    print('The model thinks this is not a fraud')"
-        ]
-       }
+   "cell_type": "markdown",
+   "id": "5f7b17c0",
+   "metadata": {},
+   "source": [
+    "## Example 1: user buys a coffee\n",
+    "\n",
+    "In this example, the user is buying a coffee. The parameters given to the model are:\n",
+    "* same location as the last transaction (distance=0)\n",
+    "* same median price (ratio_to_median=1)\n",
+    "* using pin number (pin=1)\n",
+    "* using chip (chip=1)\n",
+    "* no online transaction (online=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
+    "prediction = rest_request(data)\n",
+    "prediction\n",
+    "threshhold = 0.995\n",
+    "\n",
+    "if (prediction[0] > threshhold):\n",
+    "    print('The model thinks this is a fraud')\n",
+    "else:\n",
+    "    print('The model thinks this is not a fraud')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db10b280",
+   "metadata": {},
+   "source": [
+    "## Example 2: fraudulent transaction\n",
+    "\n",
+    "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
+    "* very far away from latest transaction (distance=100)\n",
+    "* similar median price (ratio_to_median=1.2)\n",
+    "* not using chip (chip=0)\n",
+    "* not using pin number (pin=0)\n",
+    "* online transaction (online=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "219b8927",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
+    "prediction = rest_request(data)\n",
+    "prediction\n",
+    "threshhold = 0.995\n",
+    "\n",
+    "if (prediction[0] > threshhold):\n",
+    "    print('The model thinks this is fraud')\n",
+    "else:\n",
+    "    print('The model thinks this is not fraud')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29f82fa0-c38b-4f2c-b17e-c061f24817be",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
  ],
  "metadata": {
   "kernelspec": {

--- a/5_rest_requests_single_model.ipynb
+++ b/5_rest_requests_single_model.ipynb
@@ -114,10 +114,10 @@
     "\n",
     "In this example, the user is buying a coffee. The parameters given to the model are:\n",
     "* same location as the last transaction (distance=0)\n",
-    "* same median price (ratio_to_median=1)\n",
-    "* using pin number (pin=1)\n",
-    "* using chip (chip=1)\n",
-    "* no online transaction (online=0)"
+    "* same median price as the last transaction (ratio_to_median=1)\n",
+    "* using a pin number (pin=1)\n",
+    "* using the credit card chip (chip=1)\n",
+    "* not an online transaction (online=0)"
    ]
   },
   {
@@ -133,9 +133,9 @@
     "threshhold = 0.995\n",
     "\n",
     "if (prediction[0] > threshhold):\n",
-    "    print('The model thinks this is a fraud')\n",
+    "    print('The model predicts that this is fraud')\n",
     "else:\n",
-    "    print('The model thinks this is not a fraud')"
+    "    print('The model predicts that this is not fraud')"
    ]
   },
   {
@@ -145,12 +145,12 @@
    "source": [
     "## Example 2: fraudulent transaction\n",
     "\n",
-    "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
-    "* very far away from latest transaction (distance=100)\n",
-    "* similar median price (ratio_to_median=1.2)\n",
-    "* not using chip (chip=0)\n",
-    "* not using pin number (pin=0)\n",
-    "* online transaction (online=1)"
+    "In this example, someone stole the user's credit card and is buying something online. The parameters given to the model are:\n",
+    "* very far away from the last transaction (distance=100)\n",
+    "* median price similar to the last transaction (ratio_to_median=1.2)\n",
+    "* not using a pin number (pin=0)\n",
+    "* not using the credit card chip (chip=0)\n",
+    "* is an online transaction (online=1)"
    ]
   },
   {
@@ -168,9 +168,9 @@
     "threshhold = 0.995\n",
     "\n",
     "if (prediction[0] > threshhold):\n",
-    "    print('The model thinks this is fraud')\n",
+    "    print('The model predicts that this is fraud')\n",
     "else:\n",
-    "    print('The model thinks this is not fraud')"
+    "    print('The model predicts that this is not fraud')"
    ]
   },
   {

--- a/5_rest_requests_single_model.ipynb
+++ b/5_rest_requests_single_model.ipynb
@@ -104,7 +104,70 @@
     "else:\n",
     "    print('not fraud')"
    ]
-  }
+  },
+  {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+         "## Example 1: user buys a caffe\n",
+         "\n",
+         "In this example, the user is buying a caffe. The parameters given to the model are:\n",
+         "* same location as the last transaction (distance=0)\n",
+         "* same median price (ratio_to_median=1)\n",
+         "* using pin number (pin=1)\n",
+         "* using chip (chip=1)\n",
+         "* no online transaction (online=0)"
+        ]
+       },
+       {
+        "cell_type": "code",
+        "execution_count": null,
+        "id": "f0a68b67-b109-4a2f-b097-092f4a4d25ce",
+        "metadata": {},
+        "outputs": [],
+        "source": [
+         "data = [0.0, 1.0, 1.0, 1.0, 0.0]\n",
+         "prediction = rest_request(data)\n",
+         "prediction\n",
+         "threshhold = 0.995\n",
+         "\n",
+         "if (prediction[0] > threshhold):\n",
+         "    print('The model thinks this is a fraud')\n",
+         "else:\n",
+         "    print('The model thinks this is not a fraud')"
+        ]
+       },
+       {
+        "cell_type": "markdown",
+        "metadata": {},
+        "source": [
+         "## Example 2: fraudolent transaction\n",
+         "\n",
+         "In this example, someone stole the user credit card and is buying something online. The parameters given to the model are:\n",
+         "* very far away from latest transaction (distance=100)\n",
+         "* similar median price (ratio_to_median=1.2)\n",
+         "* not using chip (chip=0)\n",
+         "* not using pin number (pin=0)\n",
+         "* online transaction (online=1)"
+        ]
+       },
+       {
+        "cell_type": "code",
+        "execution_count": null,
+        "metadata": {},
+        "outputs": [],
+        "source": [
+         "data = [100, 1.2, 0.0, 0.0, 1.0]\n",
+         "prediction = rest_request(data)\n",
+         "prediction\n",
+         "threshhold = 0.995\n",
+         "\n",
+         "if (prediction[0] > threshhold):\n",
+         "    print('The model thinks this is a fraud')\n",
+         "else:\n",
+         "    print('The model thinks this is not a fraud')"
+        ]
+       }
  ],
  "metadata": {
   "kernelspec": {


### PR DESCRIPTION
We used this workshop for our Confidential Computing fraud detection use case, see https://www.redhat.com/en/blog/confidential-containers-fsi-public-cloud and https://www.youtube.com/watch?v=KXfnV8dqu0c. 

In my opinion, having a more "concrete" example to show that the model does the correct reasoning would improve the understanding of the user. That's why I am proposing to add two examples in `3_rest_requests_multi_model.ipynb`, `4_grpc_requests_multi_model.ipynb` and `5_rest_requests_single_model.ipynb`.