### PR TITLE
update: pipeline notebook

### DIFF
--- a/7_get_data_train_upload.yaml
+++ b/7_get_data_train_upload.yaml
@@ -75,7 +75,7 @@ deploymentSpec:
           \   url = \"https://raw.githubusercontent.com/rh-aiservices-bu/fraud-detection/main/data/validate.csv\"\
           \n    urllib.request.urlretrieve(url, validate_data_output_path)\n    print(\"\
           validation data downloaded\")\n\n"
-        image: quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.9-2024a-20240523
+        image: quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.11-2024b-20250212
     exec-train-model:
       container:
         args:
@@ -90,7 +90,7 @@ deploymentSpec:
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
-          \  python3 -m pip install --quiet --no-warn-script-location 'onnx==1.17.0' 'onnxruntime==1.20.1'\
+          \  python3 -m pip install --quiet --no-warn-script-location 'onnx==1.17.0'\
           \ 'tf2onnx==1.16.1' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -155,7 +155,7 @@ deploymentSpec:
           \n    # Save the model as ONNX for easy use of ModelMesh\n    model_proto,\
           \ _ = tf2onnx.convert.from_keras(model)\n    print(model_output_path)\n\
           \    onnx.save(model_proto, model_output_path)\n\n"
-        image: quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.9-2024a-20240523
+        image: quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.11-2024b-20250212
     exec-upload-model:
       container:
         args:
@@ -170,7 +170,7 @@ deploymentSpec:
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
-          \  python3 -m pip install --quiet --no-warn-script-location 'boto3==1.35.55' 'botocore==1.35.55'\
+          \  python3 -m pip install --quiet --no-warn-script-location 'boto3==1.37.20' 'botocore==1.37.20'\
           \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -197,7 +197,7 @@ deploymentSpec:
         env:
         - name: S3_KEY
           value: models/fraud/1/model.onnx
-        image: quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.9-2024a-20240523
+        image: quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.11-2024b-20250212
 pipelineInfo:
   name: 7-get-data-train-upload
 root:

--- a/pipeline/7_get_data_train_upload.py
+++ b/pipeline/7_get_data_train_upload.py
@@ -7,7 +7,7 @@ from kfp.dsl import InputPath, OutputPath
 from kfp import kubernetes
 
 
-@dsl.component(base_image="quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.9-2024a-20240523")
+@dsl.component(base_image="quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.11-2024b-20250212")
 def get_data(train_data_output_path: OutputPath(), validate_data_output_path: OutputPath()):
     import urllib.request
     print("starting download...")
@@ -22,8 +22,8 @@ def get_data(train_data_output_path: OutputPath(), validate_data_output_path: Ou
 
 
 @dsl.component(
-    base_image="quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.9-2024a-20240523",
-    packages_to_install=["onnx==1.17.0", "onnxruntime==1.20.1", "tf2onnx==1.16.1"],
+    base_image="quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.11-2024b-20250212",
+    packages_to_install=["onnx==1.17.0", "tf2onnx==1.16.1"],
 )
 def train_model(train_data_input_path: InputPath(), validate_data_input_path: InputPath(), model_output_path: OutputPath()):
     import numpy as np
@@ -109,15 +109,15 @@ def train_model(train_data_input_path: InputPath(), validate_data_input_path: In
                         validation_data=(scaler.transform(X_val.values), y_val),
                         verbose=True, class_weight=class_weights)
 
-    # Save the model as ONNX for easy use of ModelMesh
+    # Save the model as ONNX for easy use of ModelServing
     model_proto, _ = tf2onnx.convert.from_keras(model)
     print(model_output_path)
     onnx.save(model_proto, model_output_path)
 
 
 @dsl.component(
-    base_image="quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.9-2024a-20240523",
-    packages_to_install=["boto3==1.35.55", "botocore==1.35.55"]
+    base_image="quay.io/modh/runtime-images:runtime-cuda-tensorflow-ubi9-python-3.11-2024b-20250212",
+    packages_to_install=["boto3==1.37.20", "botocore==1.37.20"]
 )
 def upload_model(input_model_path: InputPath()):
     import os


### PR DESCRIPTION
- remove onnxrt to be dependent lib for pipeline (error with train-model node:```
 ERROR: Could not find a version that satisfies the requirement onnxruntime==1.20.1 (from versions: 1.7.0, 1.8.0, 1.8.1, 1.9.0, 1.10.0, 1.11.0, 1.11.1, 1.12.0, 1.12.1, 1.13.1, 1.14.0, 1.14.1, 1.15.0, 1.15.1, 1.16.0, 1.16.1, 1.16.2, 1.16.3, 1.17.0, 1.17.1, 1.17.3, 1.18.0, 1.18.1, 1.19.0, 1.19.2)
ERROR: No matching distribution found for onnxruntime==1.20.1```)  fact is onnxrt is not used here
- uplift to new python3.11 runtime image (3.9 is not supported)
- uplift boto3, botocore version to match in the runtime image