### PR TITLE
Adding mandatory kueue.x-k8s.io/queue-name label to ray cluster

### DIFF
--- a/8_distributed_training.ipynb
+++ b/8_distributed_training.ipynb
@@ -149,6 +149,13 @@
     "    worker_cpu_limits=4,\n",
     "    worker_memory_requests=2,\n",
     "    worker_memory_limits=4\n",
+<<<<<<< Updated upstream
+    "    labels={'kueue.x-k8s.io/queue-name': 'raycluster-cpu'}\n",
+=======
+    "    # The following may be necessary if your administrator didn't setup a default queue for your namespace.\n"
+    "    # It is useful when you get the following error : 'denied request: The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set'\n"
+    "    #labels={'kueue.x-k8s.io/queue-name': '<queue-name>'}\n",
+>>>>>>> Stashed changes
     "))\n"
    ]
   },


### PR DESCRIPTION
Hi,

Creating the Ray cluster gets denied when the `kueue.x-k8s.io/queue-name` is not present or empty if the administrator did not setup a default queue for the namespace.

```
Response: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"rayclusters.ray.io \"raycluster-cpu\" is forbidden: ValidatingAdmissionPolicy 'kueue-validating-admission-policy' with binding 'kueue-validating-admission-policy-binding' denied request: The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set.","reason":"Invalid","details":{"name":"raycluster-cpu","group":"ray.io","kind":"rayclusters","causes":[{"message":"ValidatingAdmissionPolicy 'kueue-validating-admission-policy' with binding 'kueue-validating-admission-policy-binding' denied request: The label 'kueue.x-k8s.io/queue-name' is either missing or does not have a value set."}]},"code":422}
```

This PR adds an hint on the notebook for this kinds of situation that are kind of hard to debug from a RHOAI user point of view.