### PR TITLE
add "Acellerator: None" on Creating a Workbench form

### DIFF
--- a/workshop/docs/modules/ROOT/pages/creating-a-workbench.adoc
+++ b/workshop/docs/modules/ROOT/pages/creating-a-workbench.adoc
@@ -32,7 +32,7 @@ image::workbenches/create-workbench-form-image.png[Workbench image, 600]
 +
 image::workbenches/create-workbench-form-size.png[Workbench size, 600]
 
-NOTE: If your OpenShift cluster has available GPUs, the *Create workbench* form includes an *Accelerator* option. Select *None*. This {deliverable} does not require any GPUs.
+. If your OpenShift cluster has available GPUs, the *Create workbench* form includes an *Accelerator* option. Select *None*. This {deliverable} does not require any GPUs.
 
 . Leave the default environment variables and storage options.
 +

--- a/workshop/docs/modules/ROOT/pages/creating-a-workbench.adoc
+++ b/workshop/docs/modules/ROOT/pages/creating-a-workbench.adoc
@@ -32,6 +32,8 @@ image::workbenches/create-workbench-form-image.png[Workbench image, 600]
 +
 image::workbenches/create-workbench-form-size.png[Workbench size, 600]
 
+NOTE: If your OpenShift cluster has available GPUs, the *Create workbench* form includes an *Accelerator* option. Select *None*. This {deliverable} does not require any GPUs.
+
 . Leave the default environment variables and storage options.
 +
 image::workbenches/create-workbench-form-env-storage.png[Workbench storage, 600]


### PR DESCRIPTION
If the cluster has GPUs available, the Create a Workbench form will display the options in an "Accelerator" dropdown in the "Deployment size" section of the form.

I don't have MacOS so I can't update the screenshots to match what you've done in [create-workbench-form-size.png](https://github.com/rh-aiservices-bu/fraud-detection/blob/86887dc7e210fc6e867fea9f50a4b2a1a04f11b3/workshop/docs/modules/ROOT/assets/images/workbenches/create-workbench-form-size.png), but this gives you an idea of what the form looks like:

![image](https://github.com/user-attachments/assets/c9e24523-bec8-4667-ba92-7a353fc17972)

This PR updates the Create a Workbench guide to instruct users to not select an Accelerator for this workshop.

Thanks @erwangranger for pointing this out to me.
