### PR TITLE
v2.25 Fix protobuf install

### DIFF
--- a/workshop/docs/modules/ROOT/pages/index.adoc
+++ b/workshop/docs/modules/ROOT/pages/index.adoc
@@ -6,7 +6,7 @@
 [.text-center.strong]
 == Introduction
 
-:rhoai-version: v2.25
+:rhoai-version: main (the latest)
 // for the downstream tutorial, change the value of rhoai-version to match the git-version value in the importing-files-into-jupyter.adoc file
 
 [role="_abstract"]


### PR DESCRIPTION
The training notebook was failing to import keras/TensorFlow because earlier cells installed ONNX-related packages that downgraded protobuf to 3.20.x. Our OpenShift AI image’s TensorFlow 2.20.0 is built against protobuf 5.28.3, so the mismatch caused import errors. This change pins protobuf back to 5.28.3 after installing ONNX packages to restore compatibility with the platform TensorFlow.