### PR TITLE
Convert to using S4 instead of MinIO

### DIFF
--- a/3_rest_requests.ipynb
+++ b/3_rest_requests.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "Change the following variable settings to match your deployed model's *Inference endpoint*. You must edit the endpoint by specifying port *8888*, as shown in the following example:\n",
+    "Change the following variable settings to match your deployed model's *Inference endpoint*. You may need to edit the endpoint by specifying port *8888*, depending on your RHAOI configuration, as shown in the following example:\n",
     "\n",
     "```\n",
     "deployed_model_name = \"fraud\"\n",
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "deployed_model_name = \"fraud\"\n",
-    "infer_endpoint = \"http://fraud-predictor-<project-name>.<cluster>.com:8888\"\n",
+    "infer_endpoint = \"http://fraud-predictor-<project-name>.<cluster>.com<:8888>\"\n",
     "infer_url = f\"{infer_endpoint}/v2/models/{deployed_model_name}/infer\""
    ]
   },

--- a/3_rest_requests.ipynb
+++ b/3_rest_requests.ipynb
@@ -15,11 +15,11 @@
    "source": [
     "## Setup\n",
     "\n",
-    "Change the following variable settings to match your deployed model's *Inference endpoint*. You must edit the endpoint by specifying port *8888*, as shown in the following example:\n",
+    "Change the following variable settings to match your deployed model's *Inference endpoint*.\n",
     "\n",
     "```\n",
     "deployed_model_name = \"fraud\"\n",
-    "infer_endpoint = \"http://fraud-predictor-userx-workshop.apps.clusterx.sandboxx.opentlc.com:8888\"\n",
+    "infer_endpoint = \"http://fraud-predictor-userx-workshop.apps.clusterx.sandboxx.opentlc.com\"\n",
     "```\n",
     "\n",
     "\n"
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "deployed_model_name = \"fraud\"\n",
-    "infer_endpoint = \"http://fraud-predictor-<project-name>.<cluster>.com:8888\"\n",
+    "infer_endpoint = \"http://fraud-predictor-<project-name>.<cluster>.com\"\n",
     "infer_url = f\"{infer_endpoint}/v2/models/{deployed_model_name}/infer\""
    ]
   },

--- a/3_rest_requests.ipynb
+++ b/3_rest_requests.ipynb
@@ -15,11 +15,11 @@
    "source": [
     "## Setup\n",
     "\n",
-    "Change the following variable settings to match your deployed model's *Inference endpoint*.\n",
+    "Change the following variable settings to match your deployed model's *Inference endpoint*. You must edit the endpoint by specifying port *8888*, as shown in the following example:\n",
     "\n",
     "```\n",
     "deployed_model_name = \"fraud\"\n",
-    "infer_endpoint = \"http://fraud-predictor-userx-workshop.apps.clusterx.sandboxx.opentlc.com\"\n",
+    "infer_endpoint = \"http://fraud-predictor-userx-workshop.apps.clusterx.sandboxx.opentlc.com:8888\"\n",
     "```\n",
     "\n",
     "\n"
@@ -33,7 +33,7 @@
    "outputs": [],
    "source": [
     "deployed_model_name = \"fraud\"\n",
-    "infer_endpoint = \"http://fraud-predictor-<project-name>.<cluster>.com\"\n",
+    "infer_endpoint = \"http://fraud-predictor-<project-name>.<cluster>.com:8888\"\n",
     "infer_url = f\"{infer_endpoint}/v2/models/{deployed_model_name}/infer\""
    ]
   },

--- a/setup/setup-s3-job.yaml
+++ b/setup/setup-s3-job.yaml
@@ -28,7 +28,7 @@ spec:
         - args:
             - -ec
             - |-
-              echo -n 'Setting up MinIO instance and connections'
+              echo -n 'Setting up S4 instance and connections'
               oc apply -f https://github.com/rh-aiservices-bu/fraud-detection-notebooks/raw/main/setup/setup-s3-no-sa.yaml
           command:
             - /bin/bash

--- a/setup/setup-s3-job.yaml
+++ b/setup/setup-s3-job.yaml
@@ -29,7 +29,7 @@ spec:
             - -ec
             - |-
               echo -n 'Setting up S4 instance and connections'
-              oc apply -f https://github.com/rh-aiservices-bu/fraud-detection-notebooks/raw/main/setup/setup-s3-no-sa.yaml
+              oc apply -f https://github.com/rh-aiservices-bu/fraud-detection/raw/main/setup/setup-s3-no-sa.yaml
           command:
             - /bin/bash
           image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest

--- a/setup/setup-s3-no-sa.yaml
+++ b/setup/setup-s3-no-sa.yaml
@@ -1,30 +1,53 @@
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4-config
+data:
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_S3_ENDPOINT: http://localhost:7480
+  IP: 0.0.0.0
+  JWT_EXPIRATION_HOURS: "8"
+  LOCAL_STORAGE_PATHS: ""
+  MAX_CONCURRENT_TRANSFERS: "2"
+  MAX_FILE_SIZE_GB: "20"
+  PORT: "5000"
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4
 spec:
   ports:
-    - name: api
-      port: 9000
-      targetPort: api
-    - name: console
-      port: 9090
-      targetPort: 9090
+  - name: s3-api
+    port: 7480
+    protocol: TCP
+    targetPort: 7480
+  - name: web-ui
+    port: 5000
+    protocol: TCP
+    targetPort: 5000
   selector:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
   sessionAffinity: None
   type: ClusterIP
 ---
@@ -32,13 +55,13 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4-data
 spec:
   accessModes:
     - ReadWriteOnce
@@ -50,97 +73,111 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: minio
-      app.kubernetes.io/component: minio
-      app.kubernetes.io/instance: minio
-      app.kubernetes.io/name: minio
-      app.kubernetes.io/part-of: minio
-      component: minio
+      app: s4
+      app.kubernetes.io/component: storage
+      app.kubernetes.io/instance: s4
+      app.kubernetes.io/name: s4
+      app.kubernetes.io/part-of: s4
+      component: s4
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: minio
-        app.kubernetes.io/component: minio
-        app.kubernetes.io/instance: minio
-        app.kubernetes.io/name: minio
-        app.kubernetes.io/part-of: minio
-        component: minio
+        app: s4
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: s4
+        app.kubernetes.io/name: s4
+        app.kubernetes.io/part-of: s4
+        component: s4
     spec:
       containers:
-        - args:
-            - minio server /data --console-address :9090
-          command:
-            - /bin/bash
-            - -c
-          envFrom:
-            - secretRef:
-                name: minio-root-user
-          image: quay.io/minio/minio:latest
-          name: minio
+        - envFrom:
+          - configMapRef:
+              name: s4-config
+          - secretRef:
+              name: s4-credentials
+          image: quay.io/rh-aiservices-bu/s4:latest
+          name: s4
           ports:
-            - containerPort: 9000
-              name: api
+            - containerPort: 7480
+              name: s3-api
               protocol: TCP
-            - containerPort: 9090
-              name: console
+            - containerPort: 5000
+              name: web-ui
               protocol: TCP
           resources:
             limits:
               cpu: "2"
               memory: 2Gi
             requests:
-              cpu: 200m
-              memory: 1Gi
+              cpu: 250m
+              memory: 512Mi
           volumeMounts:
-            - mountPath: /data
-              name: minio
+            - mountPath: /var/lib/ceph/radosgw
+              name: s4-data
       volumes:
-        - name: minio
+        - name: s4-data
           persistentVolumeClaim:
-            claimName: minio
-        - emptyDir: {}
-          name: empty
+            claimName: s4-data
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-ds-connections
+  labels:
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
 spec:
   selector: {}
   template:
     spec:
+      initContainers:
+        - args:
+            - -ec
+            - |-
+              echo -n 'Waiting for s4-credentials secrets'
+              while ! oc get secret s4-credentials 2>/dev/null | grep -qF s4-credentials; do
+              echo -n .
+              sleep 5
+              done; echo
+
+              echo -n 'Waiting for s4-api route'
+              while ! oc get route s4-api 2>/dev/null | grep -qF s4; do
+                echo -n .
+                sleep 5
+              done; echo
+
+              echo -n 'Waiting for deployment to become available'
+              oc wait --for=condition=available --timeout=60s deployment/s4
+              sleep 3
+          command:
+            - /bin/bash
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          imagePullPolicy: IfNotPresent
+          name: wait-for-s4
       containers:
         - args:
             - -ec
             - |-
-              echo -n 'Waiting for minio route'
-              while ! oc get route minio-s3 2>/dev/null | grep -qF minio-s3; do
-                echo -n .
-                sleep 5
-              done; echo
-
-              echo -n 'Waiting for minio root user secret'
-              while ! oc get secret minio-root-user 2>/dev/null | grep -qF minio-root-user; do
-                echo -n .
-                sleep 5
-              done; echo
-
-              MINIO_ROOT_USER=$(oc get secret minio-root-user -o template --template '{{.data.MINIO_ROOT_USER}}')
-              MINIO_ROOT_PASSWORD=$(oc get secret minio-root-user -o template --template '{{.data.MINIO_ROOT_PASSWORD}}')
-              MINIO_HOST=https://$(oc get route minio-s3 -o template --template '{{.spec.host}}')
+              S4_HOST=https://$(oc get route s4-api -o template --template '{{.spec.host}}')
+              AWS_ACCESS_KEY_ID=$(oc get secret s4-credentials -o template --template '{{.data.AWS_ACCESS_KEY_ID}}')
+              AWS_SECRET_ACCESS_KEY=$(oc get secret s4-credentials -o template --template '{{.data.AWS_SECRET_ACCESS_KEY}}')
 
               cat << EOF | oc apply -f-
               apiVersion: v1
@@ -154,12 +191,12 @@ spec:
                   opendatahub.io/managed: "true"
                 name: my-storage
               data:
-                AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
-                AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+                AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+                AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
               stringData:
                 AWS_DEFAULT_REGION: us-east-1
                 AWS_S3_BUCKET: my-storage
-                AWS_S3_ENDPOINT: ${MINIO_HOST}
+                AWS_S3_ENDPOINT: ${S4_HOST}
               type: Opaque
               EOF
               cat << EOF | oc apply -f-
@@ -174,12 +211,12 @@ spec:
                   opendatahub.io/managed: "true"
                 name: pipeline-artifacts
               data:
-                AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
-                AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
+                AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+                AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
               stringData:
                 AWS_DEFAULT_REGION: us-east-1
                 AWS_S3_BUCKET: pipeline-artifacts
-                AWS_S3_ENDPOINT: ${MINIO_HOST}
+                AWS_S3_ENDPOINT: ${S4_HOST}
               type: Opaque
               EOF
           command:
@@ -195,36 +232,37 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: create-minio-buckets
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: create-s4-buckets
 spec:
   selector: {}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: minio
-        app.kubernetes.io/instance: minio
-        app.kubernetes.io/name: minio
-        app.kubernetes.io/part-of: minio
-        component: minio
+        app: s4
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: s4
+        app.kubernetes.io/name: s4
+        app.kubernetes.io/part-of: s4
+        component: s4
     spec:
       containers:
         - args:
             - -ec
             - |-
-              oc get secret minio-root-user
-              env | grep MINIO
+              oc get secret s4-credentials
               cat << 'EOF' | python3
               import boto3, os
 
               s3 = boto3.client("s3",
-                                endpoint_url="http://minio:9000",
-                                aws_access_key_id=os.getenv("MINIO_ROOT_USER"),
-                                aws_secret_access_key=os.getenv("MINIO_ROOT_PASSWORD"))
+                                endpoint_url="http://s4:7480",
+                                aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+                                aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"))
               bucket = 'pipeline-artifacts'
               print('creating pipeline-artifacts bucket')
               if bucket not in [bu["Name"] for bu in s3.list_buckets()["Buckets"]]:
@@ -238,7 +276,7 @@ spec:
             - /bin/bash
           envFrom:
             - secretRef:
-                name: minio-root-user
+                name: s4-credentials
           image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2024.1
           imagePullPolicy: IfNotPresent
           name: create-buckets
@@ -246,24 +284,24 @@ spec:
         - args:
             - -ec
             - |-
-              echo -n 'Waiting for minio root user secret'
-              while ! oc get secret minio-root-user 2>/dev/null | grep -qF minio-root-user; do
+              echo -n 'Waiting for s4-credentials secrets'
+              while ! oc get secret s4-credentials 2>/dev/null | grep -qF s4-credentials; do
               echo -n .
               sleep 5
               done; echo
 
-              echo -n 'Waiting for minio deployment'
-              while ! oc get deployment minio 2>/dev/null | grep -qF minio; do
+              echo -n 'Waiting for s4 deployment'
+              while ! oc get deployment s4 2>/dev/null | grep -qF s4; do
                 echo -n .
                 sleep 5
               done; echo
-              oc wait --for=condition=available --timeout=60s deployment/minio
+              oc wait --for=condition=available --timeout=60s deployment/s4
               sleep 10
           command:
             - /bin/bash
           image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
           imagePullPolicy: IfNotPresent
-          name: wait-for-minio
+          name: wait-for-s4
       restartPolicy: Never
       serviceAccount: demo-setup
       serviceAccountName: demo-setup
@@ -272,51 +310,57 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: create-minio-root-user
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: create-s4-credentials-secret
 spec:
   backoffLimit: 4
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: minio
-        app.kubernetes.io/instance: minio
-        app.kubernetes.io/name: minio
-        app.kubernetes.io/part-of: minio
-        component: minio
+        app: s4
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: s4
+        app.kubernetes.io/name: s4
+        app.kubernetes.io/part-of: s4
+        component: s4
     spec:
       containers:
         - args:
             - -ec
             - |-
-              if [ -n "$(oc get secret minio-root-user -oname 2>/dev/null)" ]; then
+              if [ -n "$(oc get secret s4-credentials -oname 2>/dev/null)" ]; then
                 echo "Secret already exists. Skipping." >&2
                 exit 0
               fi
               genpass() {
                   < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"${1:-32}"
               }
-              id=$(genpass 16)
-              secret=$(genpass)
+              ui_id=$(genpass 16)
+              ui_secret=$(genpass)
+              aws_accesskeyid=$(genpass 16)
+              aws_secretaccesskey=$(genpass)
               cat << EOF | oc apply -f-
               apiVersion: v1
               kind: Secret
               metadata:
-                name: minio-root-user
+                name: s4-credentials
               type: Opaque
               stringData:
-                MINIO_ROOT_USER: ${id}
-                MINIO_ROOT_PASSWORD: ${secret}
+                UI_USERNAME: ${ui_id}
+                UI_PASSWORD: ${ui_secret}
+                AWS_ACCESS_KEY_ID: ${aws_accesskeyid}
+                AWS_SECRET_ACCESS_KEY: ${aws_secretaccesskey}
               EOF
           command:
             - /bin/bash
           image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
           imagePullPolicy: IfNotPresent
-          name: create-minio-root-user
+          name: create-s4-credentials-secret
       restartPolicy: Never
       serviceAccount: demo-setup
       serviceAccountName: demo-setup
@@ -325,22 +369,22 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio-console
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4
 spec:
   port:
-    targetPort: console
+    targetPort: web-ui
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
   to:
     kind: Service
-    name: minio
+    name: s4
     weight: 100
   wildcardPolicy: None
 ---
@@ -348,21 +392,21 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio-s3
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4-api
 spec:
   port:
-    targetPort: api
+    targetPort: s3-api
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
   to:
     kind: Service
-    name: minio
+    name: s4
     weight: 100
   wildcardPolicy: None

--- a/setup/setup-s3.yaml
+++ b/setup/setup-s3.yaml
@@ -13,35 +13,58 @@ roleRef:
   kind: ClusterRole
   name: edit
 subjects:
-- kind: ServiceAccount
-  name: demo-setup
+  - kind: ServiceAccount
+    name: demo-setup
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4-config
+data:
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_S3_ENDPOINT: http://localhost:7480
+  IP: 0.0.0.0
+  JWT_EXPIRATION_HOURS: "8"
+  LOCAL_STORAGE_PATHS: ""
+  MAX_CONCURRENT_TRANSFERS: "2"
+  MAX_FILE_SIZE_GB: "20"
+  PORT: "5000"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4
 spec:
   ports:
-  - name: api
-    port: 9000
-    targetPort: api
-  - name: console
-    port: 9090
-    targetPort: 9090
+  - name: s3-api
+    port: 7480
+    protocol: TCP
+    targetPort: 7480
+  - name: web-ui
+    port: 5000
+    protocol: TCP
+    targetPort: 5000
   selector:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
   sessionAffinity: None
   type: ClusterIP
 ---
@@ -49,16 +72,16 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4-data
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
@@ -67,143 +90,157 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: minio
-      app.kubernetes.io/component: minio
-      app.kubernetes.io/instance: minio
-      app.kubernetes.io/name: minio
-      app.kubernetes.io/part-of: minio
-      component: minio
+      app: s4
+      app.kubernetes.io/component: storage
+      app.kubernetes.io/instance: s4
+      app.kubernetes.io/name: s4
+      app.kubernetes.io/part-of: s4
+      component: s4
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        app: minio
-        app.kubernetes.io/component: minio
-        app.kubernetes.io/instance: minio
-        app.kubernetes.io/name: minio
-        app.kubernetes.io/part-of: minio
-        component: minio
+        app: s4
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: s4
+        app.kubernetes.io/name: s4
+        app.kubernetes.io/part-of: s4
+        component: s4
     spec:
       containers:
-      - args:
-        - minio server /data --console-address :9090
-        command:
-        - /bin/bash
-        - -c
-        envFrom:
-        - secretRef:
-            name: minio-root-user
-        image: quay.io/minio/minio:latest
-        name: minio
-        ports:
-        - containerPort: 9000
-          name: api
-          protocol: TCP
-        - containerPort: 9090
-          name: console
-          protocol: TCP
-        resources:
-          limits:
-            cpu: "2"
-            memory: 2Gi
-          requests:
-            cpu: 200m
-            memory: 1Gi
-        volumeMounts:
-        - mountPath: /data
-          name: minio
+        - envFrom:
+          - configMapRef:
+              name: s4-config
+          - secretRef:
+              name: s4-credentials
+          image: quay.io/rh-aiservices-bu/s4:latest
+          name: s4
+          ports:
+            - containerPort: 7480
+              name: s3-api
+              protocol: TCP
+            - containerPort: 5000
+              name: web-ui
+              protocol: TCP
+          resources:
+            limits:
+              cpu: "2"
+              memory: 2Gi
+            requests:
+              cpu: 250m
+              memory: 512Mi
+          volumeMounts:
+            - mountPath: /var/lib/ceph/radosgw
+              name: s4-data
       volumes:
-      - name: minio
-        persistentVolumeClaim:
-          claimName: minio
-      - emptyDir: {}
-        name: empty
+        - name: s4-data
+          persistentVolumeClaim:
+            claimName: s4-data
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-ds-connections
+  labels:
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
 spec:
   selector: {}
   template:
     spec:
+      initContainers:
+        - args:
+            - -ec
+            - |-
+              echo -n 'Waiting for s4-credentials secrets'
+              while ! oc get secret s4-credentials 2>/dev/null | grep -qF s4-credentials; do
+              echo -n .
+              sleep 5
+              done; echo
+
+              echo -n 'Waiting for s4-api route'
+              while ! oc get route s4-api 2>/dev/null | grep -qF s4; do
+                echo -n .
+                sleep 5
+              done; echo
+
+              echo -n 'Waiting for deployment to become available'
+              oc wait --for=condition=available --timeout=60s deployment/s4
+              sleep 3
+          command:
+            - /bin/bash
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          imagePullPolicy: IfNotPresent
+          name: wait-for-s4
       containers:
-      - args:
-        - -ec
-        - |-
-          echo -n 'Waiting for minio route'
-          while ! oc get route minio-s3 2>/dev/null | grep -qF minio-s3; do
-            echo -n .
-            sleep 5
-          done; echo
+        - args:
+            - -ec
+            - |-
+              S4_HOST=https://$(oc get route s4-api -o template --template '{{.spec.host}}')
+              AWS_ACCESS_KEY_ID=$(oc get secret s4-credentials -o template --template '{{.data.AWS_ACCESS_KEY_ID}}')
+              AWS_SECRET_ACCESS_KEY=$(oc get secret s4-credentials -o template --template '{{.data.AWS_SECRET_ACCESS_KEY}}')
 
-          echo -n 'Waiting for minio root user secret'
-          while ! oc get secret minio-root-user 2>/dev/null | grep -qF minio-root-user; do
-            echo -n .
-            sleep 5
-          done; echo
-
-          MINIO_ROOT_USER=$(oc get secret minio-root-user -o template --template '{{.data.MINIO_ROOT_USER}}')
-          MINIO_ROOT_PASSWORD=$(oc get secret minio-root-user -o template --template '{{.data.MINIO_ROOT_PASSWORD}}')
-          MINIO_HOST=https://$(oc get route minio-s3 -o template --template '{{.spec.host}}')
-
-          cat << EOF | oc apply -f-
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            annotations:
-              opendatahub.io/connection-type: s3
-              openshift.io/display-name: My Storage
-            labels:
-              opendatahub.io/dashboard: "true"
-              opendatahub.io/managed: "true"
-            name: my-storage
-          data:
-            AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
-            AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
-          stringData:
-            AWS_DEFAULT_REGION: us-east-1
-            AWS_S3_BUCKET: my-storage
-            AWS_S3_ENDPOINT: ${MINIO_HOST}
-          type: Opaque
-          EOF
-          cat << EOF | oc apply -f-
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            annotations:
-              opendatahub.io/connection-type: s3
-              openshift.io/display-name: Pipeline Artifacts
-            labels:
-              opendatahub.io/dashboard: "true"
-              opendatahub.io/managed: "true"
-            name: pipeline-artifacts
-          data:
-            AWS_ACCESS_KEY_ID: ${MINIO_ROOT_USER}
-            AWS_SECRET_ACCESS_KEY: ${MINIO_ROOT_PASSWORD}
-          stringData:
-            AWS_DEFAULT_REGION: us-east-1
-            AWS_S3_BUCKET: pipeline-artifacts
-            AWS_S3_ENDPOINT: ${MINIO_HOST}
-          type: Opaque
-          EOF
-        command:
-        - /bin/bash
-        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-        imagePullPolicy: IfNotPresent
-        name: create-ds-connections
+              cat << EOF | oc apply -f-
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                annotations:
+                  opendatahub.io/connection-type: s3
+                  openshift.io/display-name: My Storage
+                labels:
+                  opendatahub.io/dashboard: "true"
+                  opendatahub.io/managed: "true"
+                name: my-storage
+              data:
+                AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+                AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              stringData:
+                AWS_DEFAULT_REGION: us-east-1
+                AWS_S3_BUCKET: my-storage
+                AWS_S3_ENDPOINT: ${S4_HOST}
+              type: Opaque
+              EOF
+              cat << EOF | oc apply -f-
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                annotations:
+                  opendatahub.io/connection-type: s3
+                  openshift.io/display-name: Pipeline Artifacts
+                labels:
+                  opendatahub.io/dashboard: "true"
+                  opendatahub.io/managed: "true"
+                name: pipeline-artifacts
+              data:
+                AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
+                AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
+              stringData:
+                AWS_DEFAULT_REGION: us-east-1
+                AWS_S3_BUCKET: pipeline-artifacts
+                AWS_S3_ENDPOINT: ${S4_HOST}
+              type: Opaque
+              EOF
+          command:
+            - /bin/bash
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          imagePullPolicy: IfNotPresent
+          name: create-ds-connections
       restartPolicy: Never
       serviceAccount: demo-setup
       serviceAccountName: demo-setup
@@ -212,75 +249,76 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: create-minio-buckets
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: create-s4-buckets
 spec:
   selector: {}
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: minio
-        app.kubernetes.io/instance: minio
-        app.kubernetes.io/name: minio
-        app.kubernetes.io/part-of: minio
-        component: minio
+        app: s4
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: s4
+        app.kubernetes.io/name: s4
+        app.kubernetes.io/part-of: s4
+        component: s4
     spec:
       containers:
-      - args:
-        - -ec
-        - |-
-          oc get secret minio-root-user
-          env | grep MINIO
-          cat << 'EOF' | python3
-          import boto3, os
+        - args:
+            - -ec
+            - |-
+              oc get secret s4-credentials
+              cat << 'EOF' | python3
+              import boto3, os
 
-          s3 = boto3.client("s3",
-                            endpoint_url="http://minio:9000",
-                            aws_access_key_id=os.getenv("MINIO_ROOT_USER"),
-                            aws_secret_access_key=os.getenv("MINIO_ROOT_PASSWORD"))
-          bucket = 'pipeline-artifacts'
-          print('creating pipeline-artifacts bucket')
-          if bucket not in [bu["Name"] for bu in s3.list_buckets()["Buckets"]]:
-            s3.create_bucket(Bucket=bucket)
-          bucket = 'my-storage'
-          print('creating my-storage bucket')
-          if bucket not in [bu["Name"] for bu in s3.list_buckets()["Buckets"]]:
-            s3.create_bucket(Bucket=bucket)
-          EOF
-        command:
-        - /bin/bash
-        envFrom:
-        - secretRef:
-            name: minio-root-user
-        image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2024.1
-        imagePullPolicy: IfNotPresent
-        name: create-buckets
+              s3 = boto3.client("s3",
+                                endpoint_url="http://s4:7480",
+                                aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID"),
+                                aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY"))
+              bucket = 'pipeline-artifacts'
+              print('creating pipeline-artifacts bucket')
+              if bucket not in [bu["Name"] for bu in s3.list_buckets()["Buckets"]]:
+                s3.create_bucket(Bucket=bucket)
+              bucket = 'my-storage'
+              print('creating my-storage bucket')
+              if bucket not in [bu["Name"] for bu in s3.list_buckets()["Buckets"]]:
+                s3.create_bucket(Bucket=bucket)
+              EOF
+          command:
+            - /bin/bash
+          envFrom:
+            - secretRef:
+                name: s4-credentials
+          image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2024.1
+          imagePullPolicy: IfNotPresent
+          name: create-buckets
       initContainers:
-      - args:
-        - -ec
-        - |-
-          echo -n 'Waiting for minio root user secret'
-          while ! oc get secret minio-root-user 2>/dev/null | grep -qF minio-root-user; do
-          echo -n .
-          sleep 5
-          done; echo
+        - args:
+            - -ec
+            - |-
+              echo -n 'Waiting for s4-credentials secrets'
+              while ! oc get secret s4-credentials 2>/dev/null | grep -qF s4-credentials; do
+              echo -n .
+              sleep 5
+              done; echo
 
-          echo -n 'Waiting for minio deployment'
-          while ! oc get deployment minio 2>/dev/null | grep -qF minio; do
-            echo -n .
-            sleep 5
-          done; echo
-          oc wait --for=condition=available --timeout=60s deployment/minio
-          sleep 10
-        command:
-        - /bin/bash
-        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-        imagePullPolicy: IfNotPresent
-        name: wait-for-minio
+              echo -n 'Waiting for s4 deployment'
+              while ! oc get deployment s4 2>/dev/null | grep -qF s4; do
+                echo -n .
+                sleep 5
+              done; echo
+              oc wait --for=condition=available --timeout=60s deployment/s4
+              sleep 10
+          command:
+            - /bin/bash
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          imagePullPolicy: IfNotPresent
+          name: wait-for-s4
       restartPolicy: Never
       serviceAccount: demo-setup
       serviceAccountName: demo-setup
@@ -289,51 +327,57 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: create-minio-root-user
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: create-s4-credentials-secret
 spec:
   backoffLimit: 4
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: minio
-        app.kubernetes.io/instance: minio
-        app.kubernetes.io/name: minio
-        app.kubernetes.io/part-of: minio
-        component: minio
+        app: s4
+        app.kubernetes.io/component: storage
+        app.kubernetes.io/instance: s4
+        app.kubernetes.io/name: s4
+        app.kubernetes.io/part-of: s4
+        component: s4
     spec:
       containers:
-      - args:
-        - -ec
-        - |-
-          if [ -n "$(oc get secret minio-root-user -oname 2>/dev/null)" ]; then
-            echo "Secret already exists. Skipping." >&2
-            exit 0
-          fi
-          genpass() {
-              < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"${1:-32}"
-          }
-          id=$(genpass 16)
-          secret=$(genpass)
-          cat << EOF | oc apply -f-
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            name: minio-root-user
-          type: Opaque
-          stringData:
-            MINIO_ROOT_USER: ${id}
-            MINIO_ROOT_PASSWORD: ${secret}
-          EOF
-        command:
-        - /bin/bash
-        image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
-        imagePullPolicy: IfNotPresent
-        name: create-minio-root-user
+        - args:
+            - -ec
+            - |-
+              if [ -n "$(oc get secret s4-credentials -oname 2>/dev/null)" ]; then
+                echo "Secret already exists. Skipping." >&2
+                exit 0
+              fi
+              genpass() {
+                  < /dev/urandom tr -dc _A-Z-a-z-0-9 | head -c"${1:-32}"
+              }
+              ui_id=$(genpass 16)
+              ui_secret=$(genpass)
+              aws_accesskeyid=$(genpass 16)
+              aws_secretaccesskey=$(genpass)
+              cat << EOF | oc apply -f-
+              apiVersion: v1
+              kind: Secret
+              metadata:
+                name: s4-credentials
+              type: Opaque
+              stringData:
+                UI_USERNAME: ${ui_id}
+                UI_PASSWORD: ${ui_secret}
+                AWS_ACCESS_KEY_ID: ${aws_accesskeyid}
+                AWS_SECRET_ACCESS_KEY: ${aws_secretaccesskey}
+              EOF
+          command:
+            - /bin/bash
+          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          imagePullPolicy: IfNotPresent
+          name: create-s4-credentials-secret
       restartPolicy: Never
       serviceAccount: demo-setup
       serviceAccountName: demo-setup
@@ -342,22 +386,22 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio-console
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4
 spec:
   port:
-    targetPort: console
+    targetPort: web-ui
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
   to:
     kind: Service
-    name: minio
+    name: s4
     weight: 100
   wildcardPolicy: None
 ---
@@ -365,21 +409,21 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   labels:
-    app: minio
-    app.kubernetes.io/component: minio
-    app.kubernetes.io/instance: minio
-    app.kubernetes.io/name: minio
-    app.kubernetes.io/part-of: minio
-    component: minio
-  name: minio-s3
+    app: s4
+    app.kubernetes.io/component: storage
+    app.kubernetes.io/instance: s4
+    app.kubernetes.io/name: s4
+    app.kubernetes.io/part-of: s4
+    component: s4
+  name: s4-api
 spec:
   port:
-    targetPort: api
+    targetPort: s3-api
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge
   to:
     kind: Service
-    name: minio
+    name: s4
     weight: 100
   wildcardPolicy: None

--- a/workshop/docs/modules/ROOT/pages/deploying-the-model.adoc
+++ b/workshop/docs/modules/ROOT/pages/deploying-the-model.adoc
@@ -15,7 +15,7 @@ You can use an {productname-short} model server to deploy the model as an API.
 
 * You have enabled a preinstalled or custom model-serving runtime.
 
-* You have obtained values for the following MinIO storage parameters:
+* You have obtained values for the following S4 storage parameters:
 ** Access Key
 ** Secret Key
 ** Endpoint
@@ -32,7 +32,7 @@ To obtain these values, navigate to your project's *Connections* tab. For the My
 The *Deploy a model* wizard opens.
 . In the *Model details* section, provide information about the model:
 .. For *Model location*, select *S3 object storage*.
-.. Enter the following values from your MinIO storage connection:
+.. Enter the following values from your S4 storage connection:
 ** Access Key
 ** Secret Key
 ** Endpoint

--- a/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
+++ b/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
@@ -4,17 +4,15 @@
 = Running a script to install local object storage buckets and create connections
 
 [role="_abstract"]
-If you do not have your own S3-compatible storage or if you want to use a disposable local MinIO instance instead, run a script (provided in the following procedure) that automatically completes these tasks:
+If you do not have your own S3-compatible storage or if you want to use a disposable local "Super Simple Storage Service" (S4) instance instead, run a script (provided in the following procedure) that automatically completes these tasks:
 
-* Creates a MinIO instance in your project.
-* Creates two storage buckets in that MinIO instance.
-* Generates a random user id and password for your MinIO instance.
+* Creates an S4 instance in your project.
+* Creates two storage buckets in that S4 instance.
+* Generates a random user id and password for your S4 instance.
 * Creates two connections in your project, one for each bucket and both using the same credentials.
 * Installs required network policies for service mesh functionality.
 
-This script is based on the link:https://ai-on-openshift.io/tools-and-applications/minio/minio/[guide for deploying MinIO].
-
-IMPORTANT: The MinIO-based Object Storage that the script creates is *not* meant for production usage.
+IMPORTANT: The S4-based Object Storage that the script creates is *not* meant for production usage.
 
 NOTE: If you want to connect to your own storage, see xref:creating-connections-to-storage.adoc[Creating connections to your own S3-compatible object storage].
 
@@ -92,7 +90,7 @@ spec:
         - args:
             - -ec
             - |-
-              echo -n 'Setting up MinIO instance and connections'
+              echo -n 'Setting up S4 instance and connections'
               oc apply -f https://github.com/rh-aiservices-bu/fraud-detection/raw/main/setup/setup-s3-no-sa.yaml
           command:
             - /bin/bash

--- a/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
+++ b/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
@@ -54,7 +54,7 @@ image::projects/ocp-console-project-selected.png[Selected project, 200]
 
 . Copy the following code and paste it into the *Import YAML* editor.
 +
-NOTE: This code is the contents of the `setup-s3-job.yaml` file and will apply the `setup-s3-no-sa.yaml` file.
+NOTE: This code is the contents of the `setup-s3-job.yaml` file. It applies the `setup-s3-no-sa.yaml` file.
 +
 [.lines_space]
 [.console-input]

--- a/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
+++ b/workshop/docs/modules/ROOT/pages/running-a-script-to-install-storage.adoc
@@ -30,7 +30,7 @@ image::projects/ds-project-list-resource-hover.png[Project list resource name, 4
 The following procedure describes how to run the script from the OpenShift console. If you are knowledgeable in OpenShift and can access the cluster from the command line, instead of following the steps in this procedure, you can use the following command to run the script:
 
 ----
-oc apply -n <your-project-name> -f https://github.com/rh-aiservices-bu/fraud-detection/raw/main/setup/setup-s3-no-sa.yaml
+oc apply -n <your-project-name> -f https://github.com/rh-aiservices-bu/fraud-detection/raw/main/setup/setup-s3-job.yaml
 ----
 ====
 
@@ -54,7 +54,7 @@ image::projects/ocp-console-project-selected.png[Selected project, 200]
 
 . Copy the following code and paste it into the *Import YAML* editor.
 +
-NOTE: This code gets and applies the `setup-s3-no-sa.yaml` file.
+NOTE: This code is the contents of the `setup-s3-job.yaml` file and will apply the `setup-s3-no-sa.yaml` file.
 +
 [.lines_space]
 [.console-input]

--- a/workshop/docs/modules/ROOT/pages/storing-data-with-connections.adoc
+++ b/workshop/docs/modules/ROOT/pages/storing-data-with-connections.adoc
@@ -6,7 +6,7 @@
 [role="_abstract"]
 Add connections to workbenches to connect your project to data inputs and object storage buckets. A connection is a resource that has the configuration parameters needed to connect to a data source or data sink, such as an AWS S3 object storage bucket.
 
-For this {deliverable}, you run a provided script that creates the following local MinIO storage buckets for you:
+For this {deliverable}, you run a provided script that creates the following local S4 storage buckets for you:
 
 * *My Storage* - Use this bucket for storing your models and data. You can reuse this bucket and its connection for your notebooks and model servers.
 *  *Pipelines Artifacts* - Use this bucket as storage for your pipeline artifacts. When you create a pipeline server, you need a pipeline artifacts bucket. For this {deliverable}, create this bucket to separate it from the first storage bucket for clarity.
@@ -15,6 +15,6 @@ NOTE: Although you can use one storage bucket for both storing models and data a
 
 The provided script also creates a connection to each storage bucket.
 
-To run the script that installs local MinIO storage buckets and creates connections to them, follow the steps in xref:running-a-script-to-install-storage.adoc[Running a script to install local object storage buckets and create connections].
+To run the script that installs local S4 storage buckets and creates connections to them, follow the steps in xref:running-a-script-to-install-storage.adoc[Running a script to install local object storage buckets and create connections].
 
 NOTE: If you want to use your own S3-compatible object storage buckets (instead of using the provided script), follow the steps in xref:creating-connections-to-storage.adoc[Creating connections to your own S3-compatible object storage].

--- a/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
+++ b/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
@@ -16,10 +16,6 @@ If the *Inference endpoint* field has an *Internal endpoint details* link, click
 +
 image::model-serving/ds-project-model-inference-endpoint.png[Model inference endpoint, 300]
 +
-*NOTE:* When you test the model API from inside a workbench, you must edit the endpoint to specify `8888` for the port. For example:
-+
-`http://fraud-predictor.fraud-detection.svc.cluster.local:8888`
-
 . Return to the JupyterLab environment and try out your new endpoint.
 +
 Follow the directions in `3_rest_requests.ipynb` to try a REST API call.

--- a/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
+++ b/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
@@ -16,7 +16,7 @@ If the *Inference endpoint* field has an *Internal endpoint details* link, click
 +
 image::model-serving/ds-project-model-inference-endpoint.png[Model inference endpoint, 300]
 +
-*NOTE:* When you test the model API from inside a workbench, you must edit the endpoint to specify `8888` for the port. For example:
+*NOTE:* When you test the model API from inside a workbench, you may need to edit the endpoint to specify `8888` for the port, depending on the configuration of your RHOAI installation. For example:
 +
 `http://fraud-predictor.fraud-detection.svc.cluster.local:8888`
 

--- a/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
+++ b/workshop/docs/modules/ROOT/pages/testing-the-model-api.adoc
@@ -16,6 +16,10 @@ If the *Inference endpoint* field has an *Internal endpoint details* link, click
 +
 image::model-serving/ds-project-model-inference-endpoint.png[Model inference endpoint, 300]
 +
+*NOTE:* When you test the model API from inside a workbench, you must edit the endpoint to specify `8888` for the port. For example:
++
+`http://fraud-predictor.fraud-detection.svc.cluster.local:8888`
+
 . Return to the JupyterLab environment and try out your new endpoint.
 +
 Follow the directions in `3_rest_requests.ipynb` to try a REST API call.


### PR DESCRIPTION
As per the title, this converts using MinIO to [S4](https://github.com/rh-aiservices-bu/s4), as this is a preferable technology.  

Tested working on the AI-BU's nightly cluster than runs RHOAI v3.4.

In addition, this PR removes the mention of specifying port 8888 when inferencing with the deployed model as I found adding this caused the connection to timeout. 

This could be to do with a change with RHOAI v3.4?