### PR TITLE
fix: update stale image tag 2024.1 to 2025.2 in setup-s3-no-sa.yaml

### DIFF
--- a/setup/setup-s3-no-sa.yaml
+++ b/setup/setup-s3-no-sa.yaml
@@ -277,7 +277,7 @@ spec:
           envFrom:
             - secretRef:
                 name: s4-credentials
-          image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2024.1
+          image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2025.2
           imagePullPolicy: IfNotPresent
           name: create-buckets
       initContainers:


### PR DESCRIPTION
## Summary

The `create-s4-buckets` Job in `setup/setup-s3-no-sa.yaml` references `s2i-generic-data-science-notebook:2024.1`, which does not exist on RHOAI 3.4+ clusters. Updated to `2025.2`.

## Problem

On RHOAI 3.4+ clusters, the pod enters `ImagePullBackOff` because the `2024.1` tag is not in the internal registry. Available tags are `2025.1`, `2025.2`, `3.4`, `3.5`.

This breaks the fraud detection tutorial (Section 2.3.1) — MinIO buckets are never created, and `2_save_model.ipynb` fails with `NoSuchBucket`.

## Change

One-line change: `2024.1` → `2025.2` in `setup/setup-s3-no-sa.yaml` line 280.

Fixes #142

🤖 Generated with [Claude Code](https://claude.ai/claude-code)