### PR TITLE
fix: use internal S3 service URL for data connections

### DIFF
--- a/setup/setup-s3-no-sa.yaml
+++ b/setup/setup-s3-no-sa.yaml
@@ -175,7 +175,7 @@ spec:
         - args:
             - -ec
             - |-
-              S4_HOST=https://$(oc get route s4-api -o template --template '{{.spec.host}}')
+              S4_HOST=http://s4.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local:7480
               AWS_ACCESS_KEY_ID=$(oc get secret s4-credentials -o template --template '{{.data.AWS_ACCESS_KEY_ID}}')
               AWS_SECRET_ACCESS_KEY=$(oc get secret s4-credentials -o template --template '{{.data.AWS_SECRET_ACCESS_KEY}}')
 

--- a/setup/setup-s3.yaml
+++ b/setup/setup-s3.yaml
@@ -192,7 +192,7 @@ spec:
         - args:
             - -ec
             - |-
-              S4_HOST=https://$(oc get route s4-api -o template --template '{{.spec.host}}')
+              S4_HOST=http://s4.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local:7480
               AWS_ACCESS_KEY_ID=$(oc get secret s4-credentials -o template --template '{{.data.AWS_ACCESS_KEY_ID}}')
               AWS_SECRET_ACCESS_KEY=$(oc get secret s4-credentials -o template --template '{{.data.AWS_SECRET_ACCESS_KEY}}')
 
@@ -294,7 +294,7 @@ spec:
           envFrom:
             - secretRef:
                 name: s4-credentials
-          image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2024.1
+          image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2025.2
           imagePullPolicy: IfNotPresent
           name: create-buckets
       initContainers:


### PR DESCRIPTION
The create-ds-connections job was configuring S3 connections with the external HTTPS route of MinIO. Pipeline pods running inside the cluster cannot validate the self-signed TLS certificate on that route, causing "x509: certificate signed by unknown authority" errors in pipeline steps (get-data, train-model, upload-model).

Switch S4_HOST from the external route to the in-cluster service URL (http://s4.<namespace>.svc.cluster.local:7480) which requires no TLS and is directly reachable from any pod in the namespace.

Also updates the stale image tag in setup-s3.yaml (2024.1 → 2025.2) to match the imagestream available on RHOAI 3.5 clusters, fixing ImagePullBackOff on the create-s4-buckets job.

Co-Authored-By: Cursor (claude-sonnet-4-6)